### PR TITLE
Close hamburger menu on click and remove jQuery

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,32 +1,89 @@
-$('.collapser').on("click", function () {
-    $(this).parent().next().collapse('toggle');
-    $(this).toggleClass('collapsed')
-});
+// Initialize behaviors
+document.addEventListener('DOMContentLoaded', () => {
 
-$("#expandAll").on("click", function () {
-    $('.accordion-collapse').collapse('show');
-});
+    // 1. Accordion Icon State Management via Bootstrap Events
+    // This ensures the icon stays in sync regardless of how the collapse is triggered (click, expand all, etc.)
+    document.querySelectorAll('.accordion-collapse').forEach(collapseEl => {
+        // When opening
+        collapseEl.addEventListener('show.bs.collapse', () => {
+            const button = collapseEl.parentElement.querySelector('.collapser');
+            if (button) button.classList.remove('collapsed');
+        });
 
-$("#collapseAll").on("click", function () {
-    $('.accordion-collapse').collapse('hide');
-});
+        // When closing
+        collapseEl.addEventListener('hide.bs.collapse', () => {
+            const button = collapseEl.parentElement.querySelector('.collapser');
+            if (button) button.classList.add('collapsed');
+        });
+    });
 
-function filterAccordions(text) {
-    // case insensitive search
-    const findText = text.toLowerCase();
+    // 2. Individual Accordion Toggles
+    document.querySelectorAll('.collapser').forEach(button => {
+        button.addEventListener('click', function (e) {
+            // Find the collapse element: parent (h3) -> next sibling (div.accordion-collapse)
+            const collapseElement = this.parentElement.nextElementSibling;
+            if (collapseElement && collapseElement.classList.contains('accordion-collapse')) {
+                const bsCollapse = bootstrap.Collapse.getOrCreateInstance(collapseElement);
+                bsCollapse.toggle();
+            }
+        });
+    });
 
-    $(".accordion-item").each(function () {
-        const accordion = $(this)
-        // If the accordion item contains the text, show it, in case it was hidden.
-        if (accordion.text().toLowerCase().indexOf(findText) >= 0) {
-            accordion.show(400);
-        } else {
-            accordion.hide(400);
+    // 3. Expand All
+    const expandAllBtn = document.getElementById("expandAll");
+    if (expandAllBtn) {
+        expandAllBtn.addEventListener("click", function (e) {
+            e.preventDefault();
+            document.querySelectorAll('.accordion-collapse').forEach(el => {
+                bootstrap.Collapse.getOrCreateInstance(el).show();
+            });
+        });
+    }
+
+    // 4. Collapse All
+    const collapseAllBtn = document.getElementById("collapseAll");
+    if (collapseAllBtn) {
+        collapseAllBtn.addEventListener("click", function (e) {
+            e.preventDefault();
+            document.querySelectorAll('.accordion-collapse').forEach(el => {
+                bootstrap.Collapse.getOrCreateInstance(el).hide();
+            });
+        });
+    }
+
+    // 5. Search filtering
+    const searchInput = document.getElementById("search");
+    if (searchInput) {
+        searchInput.addEventListener("keyup", function () {
+            const findText = this.value.toLowerCase();
+            document.querySelectorAll(".accordion-item").forEach(accordion => {
+                if (accordion.textContent.toLowerCase().includes(findText)) {
+                    accordion.classList.remove('d-none');
+                } else {
+                    accordion.classList.add('d-none');
+                }
+            });
+        });
+    }
+
+    // 6. Auto-close hamburger menu
+    document.addEventListener('click', function (event) {
+        const navbarCollapse = document.querySelector('.navbar-collapse');
+        // Only act if the menu is open
+        if (!navbarCollapse || !navbarCollapse.classList.contains('show')) {
+            return;
+        }
+
+        const isClickInside = navbarCollapse.contains(event.target);
+        const isClickOnToggler = event.target.closest('.navbar-toggler');
+        const isClickOnLink = event.target.closest('.nav-link');
+
+        // Close if click is outside menu/toggler OR if click is on a link
+        if ((!isClickInside && !isClickOnToggler) || isClickOnLink) {
+            const bsCollapse = bootstrap.Collapse.getInstance(navbarCollapse);
+            if (bsCollapse) {
+                bsCollapse.hide();
+            }
         }
     });
-}
-
-$("#search").on("keyup", function () {
-    filterAccordions($(this).val());
 });
-

--- a/template_cv.html
+++ b/template_cv.html
@@ -342,8 +342,6 @@
         href="https://github.com/eddieschoute/eddieschoute.github.io">code on Github.</a> Text &copy; 2023
       $name$</small>
   </footer>
-  <script src="https://code.jquery.com/jquery-3.7.1.min.js"
-    integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"
     integrity="sha384-geWF76RCwLtnZ8qwWowPQNguL3RmwHVBC9FhGdlKrxdiJJigb/j/68SIy3Te4Bkz"
     crossorigin="anonymous"></script>


### PR DESCRIPTION
Refactored `main.js` to remove jQuery dependency, rewriting accordion logic, expand/collapse all, and search filtering using Vanilla JS and Bootstrap 5 API. Added functionality to automatically close the mobile hamburger menu when a user clicks on a link or outside the menu. Updated `template_cv.html` to remove the jQuery import. verified logic via code review.

---
*PR created automatically by Jules for task [13329637446282973633](https://jules.google.com/task/13329637446282973633) started by @eddieschoute*