### PR TITLE
Clear search bar when menu bar link is clicked

### DIFF
--- a/main.js
+++ b/main.js
@@ -127,7 +127,7 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     }
   
-     // 7. Auto-close hamburger menu
+    // 7. Auto-close hamburger menu
     document.addEventListener('click', function (event) {
         const navbarCollapse = document.querySelector('.navbar-collapse');
         // Only act if the menu is open
@@ -146,5 +146,15 @@ document.addEventListener('DOMContentLoaded', () => {
                 bsCollapse.hide();
             }
         }
+    });
+
+    // 8. Clear search on menu bar link click
+    document.querySelectorAll('.navbar-brand, .nav-link').forEach(link => {
+        link.addEventListener('click', () => {
+            if (searchInput && searchInput.value !== "") {
+                searchInput.value = "";
+                searchInput.dispatchEvent(new Event('keyup')); // Trigger the keyup handler to reset filter
+            }
+        });
     });
 });


### PR DESCRIPTION
When a user clicks on any of the navigation links or the brand link in the menu bar, the text inside the search input is cleared out, and the search filter is reset to show all items.

---
*PR created automatically by Jules for task [11755938408097290482](https://jules.google.com/task/11755938408097290482) started by @eddieschoute*