### PR TITLE
🔒 Fix outdated Actions versions and update dependencies

### DIFF
--- a/.github/workflows/pandoc-html.yml
+++ b/.github/workflows/pandoc-html.yml
@@ -56,7 +56,7 @@ jobs:
       - run: mv public/cv.html public/index.html
       
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./public

--- a/.github/workflows/pandoc-pdf.yml
+++ b/.github/workflows/pandoc-pdf.yml
@@ -32,7 +32,7 @@ jobs:
       
       # Compile the tex file using latex
       - name: Build tex to pdf
-        uses: xu-cheng/latex-action@v2
+        uses: xu-cheng/latex-action@v3
         with:
           root_file: resume.tex
           working_directory: build
@@ -69,7 +69,7 @@ jobs:
       
       # Compile the tex file using latex
       - name: Build tex to pdf
-        uses: xu-cheng/latex-action@v2
+        uses: xu-cheng/latex-action@v3
         with:
           root_file: cv.tex
           working_directory: build
@@ -90,7 +90,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - run: mkdir build
 
       # Build the tex file using pandoc
@@ -107,7 +107,7 @@ jobs:
       
       # Compile the tex file using latex
       - name: Build tex to pdf
-        uses: xu-cheng/latex-action@v2
+        uses: xu-cheng/latex-action@v3
         with:
           root_file: publication_list.tex
           working_directory: build


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is the use of outdated GitHub Actions versions. Specifically, `actions/checkout@v2` is updated to `v4`. Additionally, `xu-cheng/latex-action` is updated from `v2` to `v3`, and `peaceiris/actions-gh-pages` is updated from `v3` to `v4`.\n\n⚠️ **Risk:** The potential impact if left unfixed includes Node 16 deprecation warnings on GitHub Actions runners. In worse-case scenarios, utilizing outdated action dependencies can leave repositories susceptible to downstream vulnerabilities and unpatched security issues.\n\n🛡️ **Solution:** The solution updates outdated actions, such as checkout, latex-action, and actions-gh-pages, to their corresponding latest major versions.

---
*PR created automatically by Jules for task [5238078076429656276](https://jules.google.com/task/5238078076429656276) started by @eddieschoute*