### PR TITLE
🔒 [security fix] Replace insecure HTTP links with HTTPS in cv.yaml

### DIFF
--- a/cv.yaml
+++ b/cv.yaml
@@ -285,7 +285,7 @@ talks:
         selected: true
         link: https://youtu.be/nWm2LKr_Nzk?t=4014
       - title: Surface code compilation via edge-disjoint paths
-        venue: '[QCTIP 2022](http://www.qctip.org/)'
+        venue: '[QCTIP 2022](https://www.qctip.org/)'
         date: 2022
         link: https://www.youtube.com/watch?v=bYJvPJtcHUE
       - title: Quantum routing with fast reversals
@@ -474,7 +474,7 @@ publications:
   - title: Shortcuts to Quantum Network Routing
     date: 2016
     author: E. Schoute
-    link: http://resolver.tudelft.nl/uuid:684bb201-64a2-461d-b603-1f47590a1341
+    link: https://resolver.tudelft.nl/uuid:684bb201-64a2-461d-b603-1f47590a1341
     description: >
       Master's thesis.
 


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed was the use of insecure `http://` links in the source YAML configuration file, specifically for the QCTIP 2022 conference and the TU Delft thesis resolver.
⚠️ **Risk:** These links are rendered in generated PDF and HTML documents. If left as HTTP, users clicking them are vulnerable to person-in-the-middle attacks, which could lead to credential theft or malware delivery on the destination sites.
🛡️ **Solution:** Replaced `http://` with `https://` for both identified links. Verified that the build process continues to work and that the generated HTML correctly includes the new secure links.

---
*PR created automatically by Jules for task [10327556722698750407](https://jules.google.com/task/10327556722698750407) started by @eddieschoute*