### PR TITLE
Fix Safari bug where Collapse All toggles instead of collapsing

### DIFF
--- a/main.js
+++ b/main.js
@@ -34,7 +34,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (expandAllBtn) {
         expandAllBtn.addEventListener("click", function (e) {
             e.preventDefault();
-            document.querySelectorAll('.accordion-collapse').forEach(el => {
+            document.querySelectorAll('.accordion-collapse:not(.show)').forEach(el => {
                 bootstrap.Collapse.getOrCreateInstance(el, { toggle: false }).show();
             });
         });
@@ -45,7 +45,7 @@ document.addEventListener('DOMContentLoaded', () => {
     if (collapseAllBtn) {
         collapseAllBtn.addEventListener("click", function (e) {
             e.preventDefault();
-            document.querySelectorAll('.accordion-collapse').forEach(el => {
+            document.querySelectorAll('.accordion-collapse.show').forEach(el => {
                 bootstrap.Collapse.getOrCreateInstance(el, { toggle: false }).hide();
             });
         });


### PR DESCRIPTION
This PR fixes an issue where clicking "Collapse All" on Safari would toggle the state of the accordions (opening closed ones and closing open ones) instead of strictly closing all of them. 

By updating the `querySelectorAll` logic for both "Collapse All" and "Expand All" in `main.js`:
- "Collapse All" now only applies `hide()` to `.accordion-collapse.show` elements.
- "Expand All" now only applies `show()` to `.accordion-collapse:not(.show)` elements.

This completely eliminates the risk of toggling already-set accordions. Tests were verified locally using Playwright with a Webkit context.

---
*PR created automatically by Jules for task [16215314400542914289](https://jules.google.com/task/16215314400542914289) started by @eddieschoute*