### PR TITLE
🧹 [code health improvement] Remove dead code block in template_cv.html patents section

### DIFF
--- a/template_cv.html
+++ b/template_cv.html
@@ -253,45 +253,6 @@
         </div>
         $endfor$
       </div>
-
-      <div class="job-entry">
-        <div class="row">
-          <div class="offset-md-1 col-md-3">
-            <h5 class="text-muted">
-              $patents.date$
-            </h5>
-          </div>
-          <div class="col-md-8">
-            <h3>$patents.title$</h3>
-          </div>
-        </div>
-        <div class="row">
-          <div class="offset-md-4 col-md-8">
-            <h4 class="text-muted">$patents.inventors$</h4>
-          </div>
-        </div>
-        $if(patents.id)$
-        <div class="row">
-          <div class="offset-md-4 col-md-8">
-            <p class="small">$patents.id$</a></p>
-          </div>
-        </div>
-        $endif$
-        $if(patents.link)$
-        <div class="row">
-          <div class="offset-md-4 col-md-8">
-            <p class="small"><a href="$patents.link$">$patents.link$</a></p>
-          </div>
-        </div>
-        $endif$
-        $if(patents.description)$
-        <div class="row">
-          <div class="offset-md-1 col-md-11">
-            $patents.description$
-          </div>
-        </div>
-        $endif$
-
     </section>
 
 


### PR DESCRIPTION
* 🎯 **What:** Removed a dead code block (lines 257-293) in `template_cv.html` inside the `<section id="patents">`. This block was a hardcoded `job-entry` layout that was never populated because the dynamic patents data is rendered in the preceding `$for(patents)$` loop using Bootstrap accordions.
* 💡 **Why:** Having orphaned, hardcoded sections inside the template causes confusion and clutters the file. Deleting this dead code makes the `template_cv.html` significantly cleaner and easier to maintain.
* ✅ **Verification:** Rebuilt the `cv.html` file using `make build/cv.html` and visually verified the generated page with Playwright. The Patents section continues to render its dynamic list correctly with accordions. Additionally, checked other template files (`template_resume.tex`, `template_cv.tex`, etc.) for similar dead code and confirmed they are clean. Ensured `package-lock.json` modifications from local npm installs were reverted so only the necessary template fix is included in this PR.
* ✨ **Result:** A cleaner, less confusing `template_cv.html` with dead code removed and functionality preserved.

---
*PR created automatically by Jules for task [9175250310479193305](https://jules.google.com/task/9175250310479193305) started by @eddieschoute*