### PR TITLE
Remove searchfield from navbar collapse

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -189,10 +189,6 @@ h5:last-child {
     white-space: nowrap;
 }
 
-.search {
-    margin-left: auto;
-}
-
 .expand {
     text-align: end;
 }
@@ -225,7 +221,16 @@ footer {
 }
 
 #search {
-    padding-right: 30px;
+    padding: 7px 30px 7px 12px;   /* gelijke hoogte als hamburger */
+}
+
+@media screen and (max-width: 576px) {
+    #search {
+        width: 136px;					/* beperkte breedte zodat het op iPhone SE past */
+    }
+    .navbar-brand {
+        margin-right: 4px;				/* idem */
+    }
 }
 
 /* Hide native search clear button in WebKit browsers */

--- a/template_cv.html
+++ b/template_cv.html
@@ -43,6 +43,10 @@
     <nav class="navbar fixed-top navbar-expand-lg bg-white">
       <div class="container-xl">
         <a class="navbar-brand" href="https://eddieschoute.github.io">Eddie Schoute</a>
+        <form class="d-flex position-relative" role="search">
+          <input class="form-control" type="search" placeholder="Search" aria-label="Search" id="search"/>
+          <span id="searchClear" class="search-clear">&times;</span>
+        </form>
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent"
           aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
           <span class="navbar-toggler-icon"></span>
@@ -56,12 +60,6 @@
             <a class="nav-link" href="#talks">Talks</a>
             <a class="nav-link" href="#patents">Patents</a>
             <a class="nav-link" href="#publications">Publications</a>
-          </div>
-          <div class="search">
-            <form class="d-flex position-relative" role="search">
-              <input class="form-control" type="search" placeholder="Search" aria-label="Search" id="search">
-              <span id="searchClear" class="search-clear">&times;</span>
-            </form>
           </div>
         </div>
       </div>


### PR DESCRIPTION
problem: drop-down menu hides search results on mobile

solution: remove the search field from the drop-down menu, and place it after navbar-brand