### PR TITLE
feat: Improve accessibility and target size of search cancel button

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -211,13 +211,21 @@ footer {
 
 .search-clear {
     position: absolute;
-    right: 10px;
+    right: 5px;
     top: 50%;
     transform: translateY(-50%);
     cursor: pointer;
     font-size: 1.2rem;
     color: #999;
     display: none;
+    width: 44px;
+    height: 44px;
+    align-items: center;
+    justify-content: center;
+    /* Reset button styles if using <button> */
+    background: transparent;
+    border: none;
+    padding: 0;
 }
 
 .search-clear:hover {
@@ -225,7 +233,7 @@ footer {
 }
 
 #search {
-    padding-right: 30px;
+    padding-right: 49px; /* Make room for the 44px button + 5px right offset */
 }
 
 /* Hide native search clear button in WebKit browsers */

--- a/template_cv.html
+++ b/template_cv.html
@@ -60,7 +60,7 @@
           <div class="search">
             <form class="d-flex position-relative" role="search">
               <input class="form-control" type="search" placeholder="Search" aria-label="Search" id="search">
-              <span id="searchClear" class="search-clear">&times;</span>
+              <button type="button" id="searchClear" class="search-clear" aria-label="Clear search">&times;</button>
             </form>
           </div>
         </div>

--- a/verify_accessibility.js
+++ b/verify_accessibility.js
@@ -1,7 +1,0 @@
-const fs = require('fs');
-const html = fs.readFileSync('build/cv.html', 'utf8');
-if (html.includes('<button type="button" id="searchClear" class="search-clear" aria-label="Clear search">&times;</button>')) {
-  console.log("Success: Button element and attributes are present in the built HTML.");
-} else {
-  console.log("Failed: Button not found in the built HTML.");
-}

--- a/verify_accessibility.js
+++ b/verify_accessibility.js
@@ -1,0 +1,7 @@
+const fs = require('fs');
+const html = fs.readFileSync('build/cv.html', 'utf8');
+if (html.includes('<button type="button" id="searchClear" class="search-clear" aria-label="Clear search">&times;</button>')) {
+  console.log("Success: Button element and attributes are present in the built HTML.");
+} else {
+  console.log("Failed: Button not found in the built HTML.");
+}


### PR DESCRIPTION
This PR improves the accessibility of the search cancel button on the CV page.

### What changed
- The `&times;` (clear) element was converted from a `<span>` to a `<button type="button">` so that it supports keyboard navigation (`Tab`, `Space`, `Enter`) by default.
- Added an `aria-label="Clear search"` attribute to improve screen reader experience.
- The clickable area (hitbox) of the button was expanded to 44x44 CSS pixels, aligning with the WCAG 2.1 Success Criterion 2.5.5 for target sizes.
- To prevent the text input from overlapping the new 44px wide target area, the padding on the right side of the search input field was increased.
- Default button styling (background, border) was stripped so that the visual appearance is functionally identical to the previous implementation.

### Why
- The old `<span>` based button was difficult to click, especially on touch devices, and was not easily reachable via keyboard for users navigating with assistive technologies. These changes bring the component up to accessibility standards.

### Verification
- Ran the HTML build via `make build/cv.html` and visually verified the frontend rendering.
- Used Playwright to screenshot and confirm that the new button takes up a 44x44 area and works as expected.

---
*PR created automatically by Jules for task [11007652496786833162](https://jules.google.com/task/11007652496786833162) started by @eddieschoute*