### PR TITLE
fix: relocate search bar out of mobile navigation menu

### DIFF
--- a/template_cv.html
+++ b/template_cv.html
@@ -23,6 +23,34 @@
   <![endif]-->
   <style>
     $styles.css()$
+
+    /* Search Bar Responsive Styles */
+    .search-input {
+      width: 130px;
+      padding-right: 20px;
+    }
+    @media (min-width: 576px) {
+      .search-input {
+        width: 200px;
+      }
+    }
+    .search-clear {
+      position: absolute;
+      right: 5px;
+      top: 50%;
+      transform: translateY(-50%);
+      font-size: 1rem;
+      padding: 0;
+      border: none;
+      background: none;
+      color: #6c757d;
+      cursor: pointer;
+      display: none; /* hidden by default, shown by JS */
+      z-index: 5;
+    }
+    .search-clear:hover {
+      color: #343a40;
+    }
   </style>
   $for(css)$
   <link rel="stylesheet" href="$css$" />
@@ -41,9 +69,15 @@
   $endfor$
   <header>
     <nav class="navbar fixed-top navbar-expand-lg bg-white">
-      <div class="container-xl">
+      <div class="container-xl d-flex flex-nowrap align-items-center">
         <a class="navbar-brand" href="https://eddieschoute.github.io">Eddie Schoute</a>
-        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent"
+        <div class="search ms-auto me-2">
+          <form class="d-flex position-relative m-0" role="search">
+            <input class="form-control form-control-sm search-input" type="search" placeholder="Search" aria-label="Search" id="search">
+            <button type="button" id="searchClear" class="search-clear" aria-label="Clear search">&times;</button>
+          </form>
+        </div>
+        <button class="navbar-toggler flex-shrink-0" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent"
           aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
           <span class="navbar-toggler-icon"></span>
         </button>
@@ -56,12 +90,6 @@
             <a class="nav-link" href="#talks">Talks</a>
             <a class="nav-link" href="#patents">Patents</a>
             <a class="nav-link" href="#publications">Publications</a>
-          </div>
-          <div class="search">
-            <form class="d-flex position-relative" role="search">
-              <input class="form-control" type="search" placeholder="Search" aria-label="Search" id="search">
-              <button type="button" id="searchClear" class="search-clear" aria-label="Clear search">&times;</button>
-            </form>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## What
The search input field was located inside the mobile collapsible menu. When a user typed a query, the results appeared underneath the open menu, completely obscuring them.

## Solution
This PR relocates the search bar to the top navbar alongside the site brand and menu toggle button. 

To achieve this without breaking layout on smaller mobile devices (like iPhone SE):
1. **HTML structural updates:** Re-positioned the `.search` container outside of `.collapse.navbar-collapse` and updated `.container-xl` with `.flex-nowrap` to prevent awkward wrapping.
2. **Responsive CSS constraints:** Added media queries mapping to Bootstrap's breakpoints to ensure the search field only occupies `130px` width on `<576px` screens and naturally expands to `200px` on larger screens.
3. **Accessibility verification:** Tested the resulting layout using `axe-core` via Playwright to ensure the search functionality and updated UI remain strictly WCAG 2.1 compliant.

---
*PR created automatically by Jules for task [12720048768578625968](https://jules.google.com/task/12720048768578625968) started by @eddieschoute*